### PR TITLE
Add header section with kickoff conf and sprint

### DIFF
--- a/2018.md
+++ b/2018.md
@@ -18,7 +18,26 @@ redirect_from:
   <h2>Toronto, Ontario</h2>
 </div>
 
-## Call for Participation
+<!-- Areas section -->
+<section class="sections row featurette-events-row">
+  <div class="four columns">
+    <h3>Kickoff</h3>
+    <span><strong>July 13</strong> • Friday</span>
+    <p>The first day has morning field trips as well as an afternoon into evening social</p>
+  </div>
+  <div class="four columns">
+    <h3>Conference</h3>
+    <span><strong>July 14-15</strong> • Saturday, Sunday</span>
+    <p>The weekend is our main event, 2 days packed full of talks, demos, and workshops</p>
+  </div>
+  <div class="four columns">
+    <h3>Sprints</h3>
+    <span><strong>July 16-18</strong> • Monday, Tuesday, Wednesday</span>
+    <p>The final 3 days are our in-person project sprints, join others or propose your own collaboration</p>
+  </div>
+</section>
+
+## Conference Call for Participation
 
 We have seen a growing number of peer-to-peer, inclusive, and privacy-respecting projects mobilizing against setbacks to resilient, accessible, equitable communications over the internet. In December 2017 the U.S. Federal Communications Commission (FCC) [voted to repeal net neutrality](http://www.cbc.ca/news/business/fcc-net-neutrality-1.4448369) rules designed to ensure a free and open internet. Further, [far-right populism](http://www.telegraph.co.uk/politics/2017/10/24/rise-populist-far-right-has-swept-europe-2017/) and growing political polarization, increased [extreme weather linked to climate change](https://www.theguardian.com/environment/2017/dec/28/climate-change-2017-warmest-year-extreme-weather), and [forced displacement](http://www.unhcr.org/afr/news/stories/2017/6/5941561f4/forced-displacement-worldwide-its-highest-decades.html) have all revealed fractures in the infrastructures of globalized systems that allow us to communicate. While these issues present new challenges, in Toronto–as elsewhere–longstanding digital inequalities are perpetuated through [uneven access to, and a lack of](https://www.toronto.ca/legdocs/mmis/2017/ed/bgrd/backgroundfile-108896.pdf), affordable internet for all.
 

--- a/2018.md
+++ b/2018.md
@@ -18,22 +18,23 @@ redirect_from:
   <h2>Toronto, Ontario</h2>
 </div>
 
-<!-- Areas section -->
+<!-- Event areas section -->
 <section class="sections row featurette-events-row">
   <div class="four columns">
     <h3>Kickoff</h3>
-    <span><strong>July 13</strong> • Friday</span>
-    <p>The first day has morning field trips as well as an afternoon into evening social</p>
+    <span>Friday • 13</span>
+    <p>We open with morning field trips and an afternoon-into-evening social event</p>
   </div>
   <div class="four columns">
     <h3>Conference</h3>
-    <span><strong>July 14-15</strong> • Saturday, Sunday</span>
+    <span>Saturday, Sunday • 14, 15</span>
     <p>The weekend is our main event, 2 days packed full of talks, demos, and workshops</p>
+
   </div>
   <div class="four columns">
     <h3>Sprints</h3>
-    <span><strong>July 16-18</strong> • Monday, Tuesday, Wednesday</span>
-    <p>The final 3 days are our in-person project sprints, join others or propose your own collaboration</p>
+    <span>Monday–Wednesday • 16–18</span>
+    <p>The final 3 days are in-person, collaborative project sprints</p>
   </div>
 </section>
 

--- a/index.md
+++ b/index.md
@@ -9,22 +9,23 @@ layout: splash
   <h2>Toronto, Ontario</h2>
 </div>
 
-<!-- Areas section -->
+<!-- Event areas section -->
 <section class="sections row featurette-events-row">
   <div class="four columns">
     <h3>Kickoff</h3>
-    <span><strong>July 13</strong> • Friday</span>
-    <p>The first day has morning field trips as well as an afternoon into evening social</p>
+    <span>Friday • 13</span>
+    <p>We open with morning field trips and an afternoon-into-evening social event</p>
   </div>
   <div class="four columns">
     <h3>Conference</h3>
-    <span><strong>July 14-15</strong> • Saturday, Sunday</span>
+    <span>Saturday, Sunday • 14, 15</span>
     <p>The weekend is our main event, 2 days packed full of talks, demos, and workshops</p>
+
   </div>
   <div class="four columns">
     <h3>Sprints</h3>
-    <span><strong>July 16-18</strong> • Monday, Tuesday, Wednesday</span>
-    <p>The final 3 days are our in-person project sprints, join others or propose your own collaboration</p>
+    <span>Monday–Wednesday • 16–18</span>
+    <p>The final 3 days are in-person, collaborative project sprints</p>
   </div>
 </section>
 

--- a/index.md
+++ b/index.md
@@ -9,12 +9,32 @@ layout: splash
   <h2>Toronto, Ontario</h2>
 </div>
 
+<!-- Areas section -->
+<section class="sections row featurette-events-row">
+  <div class="four columns">
+    <h3>Kickoff</h3>
+    <span><strong>July 13</strong> • Friday</span>
+    <p>The first day has morning field trips as well as an afternoon into evening social</p>
+  </div>
+  <div class="four columns">
+    <h3>Conference</h3>
+    <span><strong>July 14-15</strong> • Saturday, Sunday</span>
+    <p>The weekend is our main event, 2 days packed full of talks, demos, and workshops</p>
+  </div>
+  <div class="four columns">
+    <h3>Sprints</h3>
+    <span><strong>July 16-18</strong> • Monday, Tuesday, Wednesday</span>
+    <p>The final 3 days are our in-person project sprints, join others or propose your own collaboration</p>
+  </div>
+</section>
+
+## Conference Call for Participation
+
 Our theme this year focuses on how we **Do It With Others (DIWO)** as opposed to just ourselves, building on the "**distributed campaign for emancipatory, networked art practices**," instigated by UK-based [Furtherfield](http://archive.furtherfield.org/projects/diwo-do-it-others-resource) (2006) as a response to the Do It Yourself (DIY) movement. We have seen a growing number of peer-to-peer, inclusive, and privacy-respecting projects mobilizing against setbacks to resilient, accessible, equitable communications over the internet in 2017. Yet many open questions remain. In the face of threats to the open internet, which tools and tactics will help us recognize the opportunities and challenges of this moment? What kinds of creative and critical engagement with technology practices can enable meaningful change when we do it with others?
 
 **We are inviting proposals for talks, workshops, discussions, demonstrations and interventions to explore these questions.**
 
 Deadline for proposals is **April 30, 2018**, check out our full [**call for participation**](./2018) for submission instructions!
-
 
 ### Not sure? Ask us!
 


### PR DESCRIPTION
We had some language that was clearer about the plans for Our Networks before I think, but I cut it all out when publishing the CFP, here is a new spin on that. 

**UPDATED:**
<img width="862" alt="screen shot 2018-04-04 at 10 37 53 am" src="https://user-images.githubusercontent.com/4692834/38314496-56a143cc-37f4-11e8-8d88-91f0b54af4fc.png">
