### PR TITLE
Added specific call-out to clarify open nature of call

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,6 +33,8 @@ layout: splash
 
 Our theme this year focuses on how we **Do It With Others (DIWO)** as opposed to just ourselves, building on the "**distributed campaign for emancipatory, networked art practices**," instigated by UK-based [Furtherfield](http://archive.furtherfield.org/projects/diwo-do-it-others-resource) (2006) as a response to the Do It Yourself (DIY) movement. We have seen a growing number of peer-to-peer, inclusive, and privacy-respecting projects mobilizing against setbacks to resilient, accessible, equitable communications over the internet in 2017. Yet many open questions remain. In the face of threats to the open internet, which tools and tactics will help us recognize the opportunities and challenges of this moment? What kinds of creative and critical engagement with technology practices can enable meaningful change when we do it with others?
 
+**Who can submit?** Anyone interested in how we can build emancipatory communications infrastructures!
+
 **We are inviting proposals for talks, workshops, discussions, demonstrations and interventions to explore these questions.**
 
 Deadline for proposals is **April 30, 2018**, check out our full [**call for participation**](./2018) for submission instructions!


### PR DESCRIPTION
Am I understanding correcrly that less technical people are welcome (ie. ppl never having done networking tech? or perhaps no more than wordpress dev? or perhaps any tech at all)?

If so, I wonder whether we can explicitly call-out some various participant "types" (technical and otherwise) that we'd like to show up. The copy is so so clear in many ways, but I'm now about to send it out via Twitter with fresh eyes, and I'm wondering if someone might still read this assuming it's only for deeply technical people :)

Can someone else suggest the "outlier" people -- professions, roles, etc. -- that they hope to show up? I have my own sense, but I'm not 100% sure that I'm imagining it correctly...!