### PR TITLE
Notification change for successful builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ notifications:
   email:
     recipients:
       - orga@ournetworks.ca
+    on_success: never
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ notifications:
   email:
     recipients:
       - orga@ournetworks.ca
-    on_success: never
-    on_failure: always
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
@patcon following up on #7: My thinking is that we'd want to know of failed builds/test over successful ones to keep notifications light for those on `orga`