### PR TITLE
Better IA structure and secondary navigation

### DIFF
--- a/2017.md
+++ b/2017.md
@@ -4,6 +4,7 @@ order: 6
 section: "2017"
 title: "Mini-Conference"
 titleDisplay: "2017"
+parent: "About the Event"
 excerpt: 'A one-day hands-on conference about the past, present, and future of building our own network infrastructures to access the internet in our city.'
 location: Semaphore Demo Room, BL 417, Claude T. Bissell, 140 St. George St
 locationLink: http://osm.org/go/ZX6Bw~WNh--?m=

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -13,12 +13,20 @@
         {% assign current = page.url %}
         {% assign sorted_pages = site.pages | sort: "order" %}
           {% for page in sorted_pages %}
-             {% if page.order > 0 %}
+             {% if page.order > 0 and page.parent == nil %}
                <li>
                  <a class= "nav-item {% if current != '/' %}{% if page.url contains current %}active{% endif %}{% endif %}"
                     href="{{ page.url }}" aria-label="{{ page.title }}">
                     {% if page.titleDisplay %}{{ page.titleDisplay }}{% else %}{% endif %}
                  </a>
+                 <ul class="nav-item-sub">
+                    {% assign sorted2_pages = site.pages | sort: "order" %}
+                    {% for page2 in sorted2_pages %}
+                      {% if page.title == page2.parent %}
+                      <li><a class= "{% if page2.url contains current[1] %}active{% endif %}" href="{{ page2.url }}" aria-label="{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}">{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}</a></li>
+                      {% endif %}
+                    {% endfor %}
+                 </ul>
                </li>
              {% endif %}
         {% endfor %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,11 +19,11 @@
                     href="{{ page.url }}" aria-label="{{ page.title }}">
                     {% if page.titleDisplay %}{{ page.titleDisplay }}{% else %}{% endif %}
                  </a>
+                {% assign sorted2_pages = site.pages | sort: "order" %}
                  <ul class="nav-item-sub">
-                    {% assign sorted2_pages = site.pages | sort: "order" %}
                     {% for page2 in sorted2_pages %}
                       {% if page.title == page2.parent %}
-                      <li><a class= "{% if page2.url contains current[1] %}active{% endif %}" href="{{ page2.url }}" aria-label="{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}">{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}</a></li>
+                      <li><a class="{% if current != '/' %}{% if page2.url contains current %}active{% endif %}{% endif %}" href="{{ page2.url }}" aria-label="{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}">{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}</a></li>
                       {% endif %}
                     {% endfor %}
                  </ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="{{ site.url }}">
     <meta property="og:description" content="{{ sitedescription }}">
     <meta property="og:image" content="{{ site.social_image | prepend: site.url }}">
-    <link rel="stylesheet" href="/css/main.css?482018">
+    <link rel="stylesheet" href="/css/main.css?4142018">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
   </head>
   <body>
@@ -24,6 +24,6 @@
       {{ content }}
     </main>
     {% include footer.html %}
-    <script src="/js/main.js?482018"></script>
+    <script src="/js/main.js?4142018"></script>
   </body>
 </html>

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -55,6 +55,7 @@
     list-style: none;
 
     li {
+      position: relative;
       flex-grow: 1;
     }
 
@@ -129,40 +130,31 @@ input[type="checkbox"].menu-btn {
   }
 }
 
-/*Sub menu CSS*/
+// Sub-menu
 
 .nav-item-sub {
   position: absolute;
   z-index: 1000;
   display: none;
-  float: left;
   min-width: 160px;
   padding: 0;
-  font-size: inherent;
-  text-align: left;
   list-style: none;
   background: $white;
-  -webkit-background-clip: padding-box;
-  background-clip: padding-box;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, .1);
+  box-shadow: 0 3px 0 0 rgba($black, 0.1);
 
-  & > li > a {
+  li:first-child {
+    padding-top: 5px;
+  }
+
+  a {
     display: block;
-    padding: 3px 20px;
-    clear: both;
-    line-height: 1.42857143;
-    color: $black;
     white-space: nowrap;
-    padding: 10px;
+    padding: 8px 15px;
   }
 
-  li  a:hover {
-    background: rgba($white, 0.2);
-  }
-
-  .active {
-    color: $white;
-    background: rgba($white, 0.3);
+  a:hover,
+  a.active {
+    color: rgba($black, 0.5);
   }
 }
 
@@ -172,10 +164,11 @@ input[type="checkbox"].menu-btn {
 
 @media (max-width: $on-palm) {
   .nav-item-sub {
-    display:block;
-    position:inherit;
-    width:100%;
+    display: block;
+    position: inherit;
+    width: 100%;
     float: none;
     padding: 0 25px;
+    text-align: center;
   }
 }

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -128,3 +128,54 @@ input[type="checkbox"].menu-btn {
     width: 90px;
   }
 }
+
+/*Sub menu CSS*/
+
+.nav-item-sub {
+  position: absolute;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 160px;
+  padding: 0;
+  font-size: inherent;
+  text-align: left;
+  list-style: none;
+  background: $white;
+  -webkit-background-clip: padding-box;
+  background-clip: padding-box;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, .1);
+
+  & > li > a {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    line-height: 1.42857143;
+    color: $black;
+    white-space: nowrap;
+    padding: 10px;
+  }
+
+  li  a:hover {
+    background: rgba($white, 0.2);
+  }
+
+  .active {
+    color: $white;
+    background: rgba($white, 0.3);
+  }
+}
+
+.header li:hover .nav-item-sub {
+  display: block;
+}
+
+@media (max-width: $on-palm) {
+  .nav-item-sub {
+    display:block;
+    position:inherit;
+    width:100%;
+    float: none;
+    padding: 0 25px;
+  }
+}

--- a/about.md
+++ b/about.md
@@ -10,11 +10,11 @@ redirect_from:
 
 Our Networks is a conference about the past, present, and future of building our own network infrastructures. Now in its second year, the event brings together enthusiasts, hardware and software hackers, researchers, organizers and more to collectively explore creative and critical engagements with the Internet and alternative infrastructures.
 
-The event has a <a href="/code-of-conduct/">Code of Conduct</a>, in order to create an environment where we can work together. During the event if you are being harassed, notice that someone else is being harassed, or have any other concerns, we ask you to contact an organizer immediately. Those who wish to do so but don’t feel comfortable talking to the organizers in-person can email [coc@ournetworks.ca](mailto:coc@ournetworks.ca).
+The event has a <a href="/code-of-conduct/">Code of Conduct</a> in order to foster an environment where we can all work together. During the event if you are being harassed, notice that someone else is being harassed, or have any other concerns, we ask you to contact an organizer immediately. Those who wish to do so but don’t feel comfortable talking to the organizers in-person can email [coc@ournetworks.ca](mailto:coc@ournetworks.ca).
 
 We would like to acknowledge this sacred land on which Our Networks will take place. Tkaronto (Toronto) has been a site of human activity for 15,000 years. This land is the territory of the Huron-Wendat and Petun First Nations, the Seneca, and most recently, the Mississaugas of the Credit River. The territory was the subject of the Dish with One Spoon Wampum Belt Covenant, an agreement between the Iroquois Confederacy and Confederacy of the Ojibwe and allied nations to peaceably share and care for the resources around the Great Lakes. Today, the meeting place of Toronto is still the home to many Indigenous people from across Turtle Island and we are grateful to have the opportunity to work in the community, on this territory.
 
-_We are grateful to the [First Nations House](https://www.studentlife.utoronto.ca/fnh) and Elders Circle (Council of Aboriginal Initiatives) that this acknowledgement is based on._
+_We are grateful to the [First Nations House](https://www.studentlife.utoronto.ca/fnh) and Elders Circle (Council of Aboriginal Initiatives) for the language that this acknowledgement is based on._
 
 ###  Organizers
 

--- a/about.md
+++ b/about.md
@@ -22,9 +22,9 @@ Design concept and logo by [Marlo Yarlo](http://www.marloyarlo.com/).
 
 ###  Organizers
 
-Our Networks organizers have hosted civic tech events and community networks workshops, created network literacy materials, and built mesh networks with Toronto Mesh for the past two years:
+Our Networks organizers have hosted civic tech events and community networks workshops, created network literacy materials, and built mesh networking software for the past two years:
 
-**Benedict Lau**{:#benhylau} is an engineer working on mobile software and mesh networks. He is a contributor and organizer at Toronto Mesh, currently focused on meshing with single-board computers and building deployment tools and literacy around peer-to-peer applications.
+**Benedict Lau**{:#benhylau} is an engineer working on mobile software and mesh networks. He is a contributor and organizer at [Toronto Mesh](https://tomesh.net/), currently focused on meshing with single-board computers and building deployment tools and literacy around peer-to-peer applications.
 
 <ul class="bio-sm-list">
  <li class="bio-sm-list-item"><a href="http://www.groundupworks.com/" target="_blank">{% include icons/link.svg %}&nbsp;groundupworks.com </a></li>
@@ -32,7 +32,7 @@ Our Networks organizers have hosted civic tech events and community networks wor
  <li class="bio-sm-list-item"><a href="https://github.com/benhylau" target="_blank">{% include icons/github.svg %}&nbsp;benhylau</a></li>
 </ul>
 
-**Dawn Walker**{:#dawn} is a PhD student at the Faculty of Information, University of Toronto. Her research focuses on participatory design of civic environmental technologies. She also coordinates (distributed) archiving projects with [EDGI](https://envirodatagov.org/) and [Data Together](https://datatogether.org/). A keen gardener, Dawn has spent time volunteering in community gardens and urban agriculture projects.
+**Dawn Walker**{:#dawn} is a researcher and PhD student at the University of Toronto focused on participatory design tactics for building environmental civic technologies. She also imagines possibilities for grassroots and decentralized (environmental) data with [EDGI](https://envirodatagov.org/) and [Data Together](https://datatogether.org/). A keen urban agriculturalist, Dawn would rather be in the garden.
 
 <ul class="bio-sm-list">
   <li class="bio-sm-list-item"><a href="http://dcwalker.ca" target="_blank">{% include icons/link.svg %}&nbsp;dcwalker.ca</a></li>
@@ -40,7 +40,7 @@ Our Networks organizers have hosted civic tech events and community networks wor
   <li class="bio-sm-list-item"><a href="https://github.com/dcwalk" target="_blank">{% include icons/github.svg %}&nbsp;dcwalk</a></li>
 </ul>
 
-**Garry Ing**{:#garry} is a designer and technologist residing in Toronto, contributing to Toronto Mesh. His previous work and collaborations has been with the Strategic Innovation Lab (sLab) at OCAD University, the Technologies for Aging Gracefully Lab at the University of Toronto, and Normative. He is a graduate of OCAD University, with a background in graphic design.
+**Garry Ing**{:#garry} is a designer and technologist residing in Toronto, contributing to [Toronto Mesh](https://tomesh.net/). His previous work and collaborations has been with the Strategic Innovation Lab (sLab) at OCAD University, the Technologies for Aging Gracefully Lab at the University of Toronto, and Normative. He is a graduate of OCAD University, with a background in graphic design.
 
 <ul class="bio-sm-list">
   <li class="bio-sm-list-item"><a href="https://garrying.com/" target="_blank" data-proofer-ignore>{% include icons/link.svg %}&nbsp;garrying.com</a></li>
@@ -48,7 +48,7 @@ Our Networks organizers have hosted civic tech events and community networks wor
   <li class="bio-sm-list-item"><a href="https://github.com/garrying" target="_blank">{% include icons/github.svg %}&nbsp;garrying</a></li>
 </ul>
 
-**Patrick Connolly**{:#patcon} is a failed biochemist, a computer programmer, a co-organizer of CivicTech Toronto, and an anarchist sympathizer. He is interested in liquid democracy, the changing nature of work, and how we can build communities and organizations that are more open, inclusive, and resilient.
+**Patrick Connolly**{:#patcon} is a failed biochemist, a computer programmer, a co-organizer of [CivicTech Toronto](http://civictech.ca/), and an anarchist sympathizer. He is interested in liquid democracy, the changing nature of work, and how we can build communities and organizations that are more open, inclusive, and resilient.
 
 <ul class="bio-sm-list">
   <li class="bio-sm-list-item"><a href="https://twitter.com/patconnolly" target="_blank">{% include icons/twitter.svg %}&nbsp;@patconnolly</a></li>

--- a/about.md
+++ b/about.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-order: 10
+order: 1
 section: "2018"
 title: "About the Event"
 titleDisplay: "About"
@@ -10,19 +10,15 @@ redirect_from:
 
 Our Networks is a conference about the past, present, and future of building our own network infrastructures. Now in its second year, the event brings together enthusiasts, hardware and software hackers, researchers, organizers and more to collectively explore creative and critical engagements with the Internet and alternative infrastructures.
 
-The event has a <a href="/code-of-conduct/">Code of Conduct</a>, in order to create an environment where we can work together. During the event if you are being harassed, notice that someone else is being harassed, or have any other concerns, we ask you to contact an organizer immediately. Those who wish to do so but don’t feel comfortable talking to the organizers in-person can email <a href="mailto:coc@ournetworks.ca">coc@ournetworks.ca</a>.
+The event has a <a href="/code-of-conduct/">Code of Conduct</a>, in order to create an environment where we can work together. During the event if you are being harassed, notice that someone else is being harassed, or have any other concerns, we ask you to contact an organizer immediately. Those who wish to do so but don’t feel comfortable talking to the organizers in-person can email [coc@ournetworks.ca](mailto:coc@ournetworks.ca).
 
-###  Design
+We would like to acknowledge this sacred land on which Our Networks will take place. Tkaronto (Toronto) has been a site of human activity for 15,000 years. This land is the territory of the Huron-Wendat and Petun First Nations, the Seneca, and most recently, the Mississaugas of the Credit River. The territory was the subject of the Dish with One Spoon Wampum Belt Covenant, an agreement between the Iroquois Confederacy and Confederacy of the Ojibwe and allied nations to peaceably share and care for the resources around the Great Lakes. Today, the meeting place of Toronto is still the home to many Indigenous people from across Turtle Island and we are grateful to have the opportunity to work in the community, on this territory.
 
-Design concept and logo by [Marlo Yarlo](http://www.marloyarlo.com/).
-
-<ul class="bio-sm-list">
-  <li class="bio-sm-list-item"><a href="http://www.marloyarlo.com/" target="_blank">{% include icons/link.svg %}&nbsp;marloyarlo.com</a></li>
-</ul>
+_We are grateful to the [First Nations House](https://www.studentlife.utoronto.ca/fnh) and Elders Circle (Council of Aboriginal Initiatives) that this acknowledgement is based on._
 
 ###  Organizers
 
-Our Networks organizers have hosted civic tech events and community networks workshops, created network literacy materials, and built mesh networking software for the past two years:
+Our Networks organizers have hosted civic tech events and community networks workshops, created network literacy materials, and built mesh networking software for the past two years.
 
 **Benedict Lau**{:#benhylau} is an engineer working on mobile software and mesh networks. He is a contributor and organizer at [Toronto Mesh](https://tomesh.net/), currently focused on meshing with single-board computers and building deployment tools and literacy around peer-to-peer applications.
 
@@ -60,6 +56,14 @@ Our Networks organizers have hosted civic tech events and community networks wor
   <li class="bio-sm-list-item"><a href="https://isthisa.com/" target="_blank">{% include icons/link.svg %}&nbsp;isthisa.com</a></li>
   <li class="bio-sm-list-item"><a href="https://twitter.com/isthisanart_" target="_blank">{% include icons/twitter.svg %}&nbsp;@isthisanart_</a></li>
   <li class="bio-sm-list-item"><a href="https://github.com/ana0" target="_blank">{% include icons/github.svg %}&nbsp;ana0</a></li>
+</ul>
+
+###  Design
+
+Design concept and logo by [Marlo Yarlo](http://www.marloyarlo.com/).
+
+<ul class="bio-sm-list">
+  <li class="bio-sm-list-item"><a href="http://www.marloyarlo.com/" target="_blank">{% include icons/link.svg %}&nbsp;marloyarlo.com</a></li>
 </ul>
 
 ### I want to make this event better, how can I help?

--- a/about.md
+++ b/about.md
@@ -4,18 +4,23 @@ order: 10
 section: "2018"
 title: "About the Event"
 titleDisplay: "About"
+redirect_from:
+  - "/2018/about"
 ---
 
 Our Networks is a conference about the past, present, and future of building our own network infrastructures. Now in its second year, the event brings together enthusiasts, hardware and software hackers, researchers, organizers and more to collectively explore creative and critical engagements with the Internet and alternative infrastructures.
 
-Our Networks has a <a href="/code-of-conduct/">Code of Conduct</a>, for any conduct reports or concerns please email <a href="mailto:coc@ournetworks.ca">coc@ournetworks.ca</a>.
+The event has a <a href="/code-of-conduct/">Code of Conduct</a>, in order to create an environment where we can work together. During the event if you are being harassed, notice that someone else is being harassed, or have any other concerns, we ask you to contact an organizer immediately. Those who wish to do so but don’t feel comfortable talking to the organizers in-person can email <a href="mailto:coc@ournetworks.ca">coc@ournetworks.ca</a>.
 
+###  Design
 
-### I want to make this even even better, how can I help?
+Design concept and logo by [Marlo Yarlo](http://www.marloyarlo.com/).
 
-You should consider [tabling at our Yami-ichi](/yami-ichi/) or [pitching a project for our Sprints](/2018/sprints/). We are [planning this event openly](https://github.com/ournetworks/2018) so you can also check tasks we are working on. If those activities don't appeal to you, we will need volunteers to help the event run smoothly--reach out to us at <a href="mailto:{{ site.email }}">{{ site.email }}</a> to be added to the volunteer list.
+<ul class="bio-sm-list">
+  <li class="bio-sm-list-item"><a href="http://www.marloyarlo.com/" target="_blank">{% include icons/link.svg %}&nbsp;marloyarlo.com</a></li>
+</ul>
 
-###  Organizing Team
+###  Organizers
 
 Our Networks organizers have hosted civic tech events and community networks workshops, created network literacy materials, and built mesh networks with Toronto Mesh for the past two years:
 
@@ -57,10 +62,6 @@ Our Networks organizers have hosted civic tech events and community networks wor
   <li class="bio-sm-list-item"><a href="https://github.com/ana0" target="_blank">{% include icons/github.svg %}&nbsp;ana0</a></li>
 </ul>
 
-###  Design
+### I want to make this event better, how can I help?
 
-Design concept and logo by [Marlo Yarlo](http://www.marloyarlo.com/).
-
-<ul class="bio-sm-list">
-  <li class="bio-sm-list-item"><a href="http://www.marloyarlo.com/" target="_blank">{% include icons/link.svg %}&nbsp;marloyarlo.com</a></li>
-</ul>
+You should consider [tabling at our Yami-ichi](/yami-ichi/) or [pitching a project for our Sprints](/2018/sprints/). We are [planning this event openly](https://github.com/ournetworks/2018) so you can also check tasks we are working on. If those activities don't appeal to you, we will need volunteers to help the event run smoothly--reach out to us at <a href="mailto:{{ site.email }}">{{ site.email }}</a> to be added to the volunteer list.

--- a/about.md
+++ b/about.md
@@ -68,4 +68,4 @@ Design concept and logo by [Marlo Yarlo](http://www.marloyarlo.com/).
 
 ### I want to make this event better, how can I help?
 
-You should consider [tabling at our Yami-ichi](/yami-ichi/) or [pitching a project for our Sprints](/2018/sprints/). We are [planning this event openly](https://github.com/ournetworks/2018) so you can also check tasks we are working on. If those activities don't appeal to you, we will need volunteers to help the event run smoothly--reach out to us at <a href="mailto:{{ site.email }}">{{ site.email }}</a> to be added to the volunteer list.
+You should consider [tabling at our Yami-ichi](/yami-ichi/) or [pitching a project for our Sprints](/sprints/). We are [planning this event openly](https://github.com/ournetworks/2018) so you can also check tasks we are working on. If those activities don't appeal to you, we will need volunteers to help the event run smoothly--reach out to us at <a href="mailto:{{ site.email }}">{{ site.email }}</a> to be added to the volunteer list.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,7 +1,8 @@
 ---
 layout: page
-order: 0
+order: 1
 title: "Code of Conduct"
+parent: "About the Event"
 ---
 
 Our Networks is dedicated to providing a harassment-free environment for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion or technical skill level.

--- a/conference.md
+++ b/conference.md
@@ -9,6 +9,8 @@ endDate: 2018-07-15
 venueName: "Mozilla Community Space"
 location: "Suite 500, 366 Adelaide Street"
 locationLink: https://osm.org/go/ZX6BjZ50h?m=
+redirect_from:
+  - "/2018/conference"
 ---
 
 

--- a/conference.md
+++ b/conference.md
@@ -10,7 +10,7 @@ venueName: "Mozilla Community Space"
 location: "Suite 500, 366 Adelaide Street"
 locationLink: https://osm.org/go/ZX6BjZ50h?m=
 redirect_from:
-  - "/2018/conferences"
+  - "/2018/conference/"
 ---
 
 

--- a/conference.md
+++ b/conference.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-order: 2
+order: 3
 section: "2018"
 title: "Conference"
 titleDisplay: "Conference"
@@ -10,7 +10,7 @@ venueName: "Mozilla Community Space"
 location: "Suite 500, 366 Adelaide Street"
 locationLink: https://osm.org/go/ZX6BjZ50h?m=
 redirect_from:
-  - "/2018/conference"
+  - "/2018/conferences"
 ---
 
 

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ What kinds of creative and critical engagement with technology practices can ena
 
 Our theme this year focuses on how we **Do It With Others (DIWO)** as opposed to just ourselves, building on the “distributed campaign for emancipatory, networked art practices,” instigated by UK-based Furtherfield (2006) as a response to the Do It Yourself (DIY) movement. We have seen a growing number of peer-to-peer, inclusive, and privacy-respecting projects mobilizing in favour of resilient, accessible, equitable communications over the internet in 2017. And yet many open questions remain. In the face of threats to the open internet, which tools and tactics will help us recognize the opportunities and challenges of this moment?
 
-The deadline for conference proposals has now closed, check back late-May for our full conference schedule! In the meantime, are you interested in [selling your stuff](/2018/kickoff-yami-ichi/) at our Internet Yami-ichi? Or [hosting a project](/2018/sprints/) during our Sprints?
+The deadline for conference proposals has now closed, check back late-May for our full conference schedule! In the meantime, are you interested in [selling your stuff](/yami-ichi/) at our Internet Yami-ichi? Or [hosting a project](/sprints/) during our Sprints?
 
 {% include graphics/asterisk-outline.svg %}
 {% include graphics/stairs-outline.svg %}

--- a/sprints.md
+++ b/sprints.md
@@ -9,6 +9,8 @@ endDate: 2018-07-18
 venueName: "Semaphore Demo Room"
 location: "Room 417, Claude T. Bissell, 140 St. George Street"
 locationLink: http://osm.org/go/ZX6Bw~WNh--?m=
+redirect_from:
+  - "/2018/sprint"
 ---
 
 

--- a/sprints.md
+++ b/sprints.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-order: 3
+order: 4
 section: "2018"
 title: "Sprints"
 titleDisplay: "Sprints"

--- a/sprints.md
+++ b/sprints.md
@@ -10,7 +10,7 @@ venueName: "Semaphore Demo Room"
 location: "Room 417, Claude T. Bissell, 140 St. George Street"
 locationLink: http://osm.org/go/ZX6Bw~WNh--?m=
 redirect_from:
-  - "/2018/sprint"
+  - "/2018/sprints/"
 ---
 
 

--- a/visiting.md
+++ b/visiting.md
@@ -8,7 +8,7 @@ redirect_from:
   - "/2018/visiting"
 ---
 
-We have a slowly-growing list of questions for those visiting the event, if you don't see yours answered below, send us an email at {{ site.email }}.
+We have a slowly-growing list of questions for those visiting Tkaronto (Toronto), if you don't see yours answered below, send us an email at [{{ site.email }}](mailto:{{ site.email }}).
 
 ### I am traveling from out of town, how can I stay in Toronto affordably? (a.k.a. What are community billets?)
 
@@ -24,4 +24,4 @@ We are committed to reducing barriers to access throughout the event. All spaces
 
 ### I want to make this even even better, how can I help?
 
-Awesome! First, consider [tabling at our Yami-ichi](/yami-ichi/) or [pitching a project for our Sprints](/2018/sprints/). If those don't appeal we'd love to have weekend volunteers, email us at {{ site.email }}!
+Awesome! First, consider [tabling at our Yami-ichi](/yami-ichi/) or [pitching a project for our Sprints](/sprints/). If those don't appeal we'd love to have weekend volunteers, email us at [{{ site.email }}](mailto:{{ site.email }})!

--- a/visiting.md
+++ b/visiting.md
@@ -4,6 +4,8 @@ order: 11
 section: "2018"
 title: "Visiting Toronto"
 titleDisplay: "Visiting"
+redirect_from:
+  - "/2018/visiting"
 ---
 
 We have a slowly-growing list of questions for those visiting the event, if you don't see yours answered below, send us an email at {{ site.email }}.

--- a/yami-ichi.md
+++ b/yami-ichi.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-order: 1
+order: 2
 section: "2018"
 title: "Kickoff Yami-ichi"
 titleDisplay: "Yami-Ichi"


### PR DESCRIPTION
Hey, I'm feeling a little indecisive sorry for springing this-- but I think our website structure is a little confusing. I did a (cribbed) cleanup. Unfortunately I didn't keep this PR super clean and a couple commits are link fixes and an update to my bio.

Welcome your thoughts! 

<img width="816" alt="screen shot 2018-05-13 at 9 33 27 pm" src="https://user-images.githubusercontent.com/4692834/39974269-85b30252-56f5-11e8-804d-e36ad7fc1c00.png">

(basically: cut out the 2018 structure until the event ends, this is the IA:

```
. Home Splash (Registration)
├── About ✔︎
│   ├── 2017  ✔︎
│   └── Code of Conduct  ✔︎
├── 2018   ✘ (same as HOME until 2018 ends)
├── Yami-ichi 
├── Conference 
├── Sprints ✔︎
└── Visiting Toronto ✔︎
```
