### PR TITLE
Fix menu active states, iOS menu click fix, Marlo Instagram

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,7 +15,7 @@
           {% for page in sorted_pages %}
              {% if page.order > 0 and page.parent == nil %}
                <li>
-                 <a class= "nav-item {% if current != '/' %}{% if page.url contains current %}active{% endif %}{% endif %}"
+                 <a class= "nav-item {% if current != '/' %}{% if page.url == current %}active{% endif %}{% endif %}"
                     href="{{ page.url }}" aria-label="{{ page.title }}">
                     {% if page.titleDisplay %}{{ page.titleDisplay }}{% else %}{% endif %}
                  </a>
@@ -23,7 +23,7 @@
                  <ul class="nav-item-sub" aria-hidden="true">
                     {%- for page2 in sorted2_pages -%}
                       {% if page.title == page2.parent %}
-                      <li><a class="{% if current != '/' %}{% if page2.url contains current %}active{% endif %}{% endif %}" href="{{ page2.url }}" aria-label="{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}">{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}</a></li>
+                      <li><a class="{% if current != '/' %}{% if page2.url == current %}active{% endif %}{% endif %}" href="{{ page2.url }}" aria-label="{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}">{% if page2.titleDisplay %}{{ page2.titleDisplay }}{% else %}{{ page2.title }}{% endif %}</a></li>
                       {% endif %}
                     {%- endfor -%}
                  </ul>

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -173,6 +173,13 @@ input[type="checkbox"].menu-btn {
 }
 
 @media (max-width: $on-palm) {
+  .header {
+    li:hover {
+      .nav-item-sub:empty {
+        display: none;
+      }
+    }
+  }
   .nav-item-sub {
     display: block;
     position: inherit;

--- a/_sass/_tables.scss
+++ b/_sass/_tables.scss
@@ -2,6 +2,7 @@
 
 table {
   border-spacing: 0;
+  margin: 1em 0;
 }
 
 th,
@@ -29,7 +30,7 @@ thead th {
 // Schedule Table
 
 .schedule-table {
-  margin: 1em 0 4em;
+  margin-bottom: 4em;
   width: 100%;
 
   h3,

--- a/about.md
+++ b/about.md
@@ -63,6 +63,7 @@ Our Networks organizers have hosted civic tech events and community networks wor
 Design concept and logo by [Marlo Yarlo](http://www.marloyarlo.com/).
 
 <ul class="bio-sm-list">
+  <li class="bio-sm-list-item"><a href="https://www.instagram.com/marloyarlo/" target="_blank" rel="noopener">{% include icons/instagram.svg %}&nbsp;marloyarlo</a></li>
   <li class="bio-sm-list-item"><a href="http://www.marloyarlo.com/" target="_blank" rel="noopener">{% include icons/link.svg %}&nbsp;marloyarlo.com</a></li>
 </ul>
 


### PR DESCRIPTION
- Marlo requested adding her insta :)
- `/conference/program/` is a little different from our other submenu links in that the permalink is prefixed with `/conference/` instead of being top-level. Bug was selecting `/conference` was also highlighting `program` in the submenu
- Fixes an issue with `:hover` being applied on click when a menu item doesn't have a submenu. Meant that one needed to double-tap to navigate to a page