### PR TITLE
Share 2019 dates

### DIFF
--- a/_includes/2019-hero.html
+++ b/_includes/2019-hero.html
@@ -2,7 +2,7 @@
   <div class="container">
   <header>
     <h1 style="margin-bottom: 0;">RE: Infrastructures</h1>
-    <h2 style="margin-bottom: 1em;">September 2019</h2>
+    <h2 style="margin-bottom: 1em;">September 20-22, 2019</h2>
     <h3 style="margin-top: 0;">Toronto, Ontario</h3>
   </header>
   </div>


### PR DESCRIPTION
This finalizes https://github.com/ournetworks/2019/issues/9, tho similar to https://github.com/ournetworks/2019/pull/30, ~this should sit a couple days until the final LOA lands?~

We are good to add the dates to the website! We should do this soon!

Announcement (from https://github.com/ournetworks/2019/issues/10)
- [x] dates
- ~CFP~ 
- ~open hours~


Question: should we role in the CFP and do a bit more of an edit to the main page in the process?

Edit: discussed with @garrying and we'll keep this just to dates!