### PR TITLE
Update to ipfs.infura.io Gateway

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ permalink: pretty
 twitter_username:
 github_username: ournetworks
 social_image: /images/social.png
+ipfs_gateway: https://ipfs.infura.io/ipfs
 
 # Build settings
 sass:

--- a/_includes/session-video.html
+++ b/_includes/session-video.html
@@ -36,8 +36,8 @@
       <h5 class="session-heading-small">Watch elsewhere:</h5>
       {%- if session.ipfs720 or session.ipfs1080 or session.youtube -%}
         <ul class="video-links">
-         {%- if session.ipfs720 -%}<li class="video-links-item"><a href="https://ipfs.infura.io/ipfs/{{ session.ipfs720 }}" target="_blank" rel="noopener">{% include icons/ipfs.svg %}&nbsp;<code>[&nbsp;720p]</code>ipfs://{{ session.ipfs720 }}</a></li>{%- endif -%}
-         {%- if session.ipfs1080 -%}<li class="video-links-item"><a href="https://ipfs.infura.io/ipfs/{{ session.ipfs1080 }}" target="_blank" rel="noopener">{% include icons/ipfs.svg %}&nbsp;<code>[1080p]</code>ipfs://{{ session.ipfs1080 }}</a></li>{%- endif -%}
+         {%- if session.ipfs720 -%}<li class="video-links-item"><a href="{{ site.ipfs_gateway }}/{{ session.ipfs720 }}" target="_blank" rel="noopener">{% include icons/ipfs.svg %}&nbsp;<code>[&nbsp;720p]</code>ipfs://{{ session.ipfs720 }}</a></li>{%- endif -%}
+         {%- if session.ipfs1080 -%}<li class="video-links-item"><a href="{{ site.ipfs_gateway }}/{{ session.ipfs1080 }}" target="_blank" rel="noopener">{% include icons/ipfs.svg %}&nbsp;<code>[1080p]</code>ipfs://{{ session.ipfs1080 }}</a></li>{%- endif -%}
          {%- if session.youtube -%}<li class="video-links-item"><a href="https://youtu.be/{{ session.youtube }}" target="_blank" rel="noopener">{% include icons/youtube.svg %}&nbsp;youtu.be/{{ session.youtube }}</a></li>{%- endif -%}
         </ul>
       {%- endif -%}

--- a/_includes/session-video.html
+++ b/_includes/session-video.html
@@ -36,8 +36,8 @@
       <h5 class="session-heading-small">Watch elsewhere:</h5>
       {%- if session.ipfs720 or session.ipfs1080 or session.youtube -%}
         <ul class="video-links">
-         {%- if session.ipfs720 -%}<li class="video-links-item"><a href="http://ipfs.io/ipfs/{{ session.ipfs720 }}" target="_blank" rel="noopener">{% include icons/ipfs.svg %}&nbsp;<code>[&nbsp;720p]</code>ipfs://{{ session.ipfs720 }}</a></li>{%- endif -%}
-         {%- if session.ipfs1080 -%}<li class="video-links-item"><a href="http://ipfs.io/ipfs/{{ session.ipfs1080 }}" target="_blank" rel="noopener">{% include icons/ipfs.svg %}&nbsp;<code>[1080p]</code>ipfs://{{ session.ipfs1080 }}</a></li>{%- endif -%}
+         {%- if session.ipfs720 -%}<li class="video-links-item"><a href="https://ipfs.infura.io/ipfs/{{ session.ipfs720 }}" target="_blank" rel="noopener">{% include icons/ipfs.svg %}&nbsp;<code>[&nbsp;720p]</code>ipfs://{{ session.ipfs720 }}</a></li>{%- endif -%}
+         {%- if session.ipfs1080 -%}<li class="video-links-item"><a href="https://ipfs.infura.io/ipfs/{{ session.ipfs1080 }}" target="_blank" rel="noopener">{% include icons/ipfs.svg %}&nbsp;<code>[1080p]</code>ipfs://{{ session.ipfs1080 }}</a></li>{%- endif -%}
          {%- if session.youtube -%}<li class="video-links-item"><a href="https://youtu.be/{{ session.youtube }}" target="_blank" rel="noopener">{% include icons/youtube.svg %}&nbsp;youtu.be/{{ session.youtube }}</a></li>{%- endif -%}
         </ul>
       {%- endif -%}

--- a/_includes/video-player-embed.html
+++ b/_includes/video-player-embed.html
@@ -14,7 +14,7 @@
             <span class="button-label">IPFS</span>
           </button>
           <div class="stream-option-title-helper">
-            <p>Play the stream through a peer-to-peer hypermedia protocol. More at <a href="https://ipfs.io" target="_blank">ipfs.io</a></p>
+            <p>Play the stream through a peer-to-peer hypermedia protocol. More at <a href="https://ipfs.io" target="_blank" data-proofer-ignore>ipfs.io</a></p>
           </div>
         </div>
         <div class="stream-option-wrapper" id="httpStream">

--- a/recorded-talks.md
+++ b/recorded-talks.md
@@ -12,7 +12,7 @@ redirect_from:
 
 Full archives of 2018 videos are available:
 
-- IPFS: [ipfs://QmQQfD1ztg1aG82VmUmutusbxn7tL4c2o1qHv1ivyWbNj6](https://ipfs.infura.io/ipfs/QmQQfD1ztg1aG82VmUmutusbxn7tL4c2o1qHv1ivyWbNj6/)
+- IPFS: [ipfs://QmQQfD1ztg1aG82VmUmutusbxn7tL4c2o1qHv1ivyWbNj6]({{ site.ipfs_gateway }}/QmQQfD1ztg1aG82VmUmutusbxn7tL4c2o1qHv1ivyWbNj6/)
 - Internet Archive: [Our Networks 2018 Talks](https://archive.org/details/ournetworks2018) (torrent available)
 - YouTube playlist: [Our Networks 2018 Beyond DIY: Do It With Others](https://www.youtube.com/playlist?list=PLx7_J32Ys60ey2bgSn2soAoBy0v9bBUbT)
 

--- a/recorded-talks.md
+++ b/recorded-talks.md
@@ -12,7 +12,7 @@ redirect_from:
 
 Full archives of 2018 videos are available:
 
-- IPFS: [ipfs://QmQQfD1ztg1aG82VmUmutusbxn7tL4c2o1qHv1ivyWbNj6](https://ipfs.io/ipfs/QmQQfD1ztg1aG82VmUmutusbxn7tL4c2o1qHv1ivyWbNj6/)
+- IPFS: [ipfs://QmQQfD1ztg1aG82VmUmutusbxn7tL4c2o1qHv1ivyWbNj6](https://ipfs.infura.io/ipfs/QmQQfD1ztg1aG82VmUmutusbxn7tL4c2o1qHv1ivyWbNj6/)
 - Internet Archive: [Our Networks 2018 Talks](https://archive.org/details/ournetworks2018) (torrent available)
 - YouTube playlist: [Our Networks 2018 Beyond DIY: Do It With Others](https://www.youtube.com/playlist?list=PLx7_J32Ys60ey2bgSn2soAoBy0v9bBUbT)
 


### PR DESCRIPTION
Suggesting that we use `ipfs.infura.io` for gateway since `ipfs.io` is having issues. Might be misremembering: Were there other gateways we could use?

This could be a temp fix for now.