### PR TITLE
Enable autoplay IPFS when HTTP URLs is not defined.

### DIFF
--- a/js/video-player-embed.js
+++ b/js/video-player-embed.js
@@ -200,6 +200,7 @@ live.on('error', function(event) {
 
 if (!stream_urls_http || !Array.isArray(stream_urls_http) || (stream_urls_http.length === 0)) {
   document.querySelector('.http-stream').setAttribute('disabled', 'disabled');
+  ipfsStream();
 }
 
 // Video sharing links


### PR DESCRIPTION
We tested this and it works, this PR removes the HTTP / IPFS selection screen when only IPFS is there.  If HTTP is defined it will still appear like it does currently.