### PR TITLE
Add video stream code attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/ournetworks/ournetworks.ca.svg?branch=master)](https://travis-ci.org/ournetworks/ournetworks.ca)
 
-This repository holds the source code and static assets of [ournetworks.ca](http://ournetworks.ca), built with [Jekyll](https://jekyllrb.com/), [Normalize.css](http://necolas.github.io/normalize.css/), and icons from [Font Awesome](http://fontawesome.io/). Live stream graphic assets from [IPFS](https://github.com/ipfs/artwork) and loading animation from [jxnblk/loading](https://github.com/jxnblk/loading).
+This repository holds the source code and static assets of [ournetworks.ca](http://ournetworks.ca), built with [Jekyll](https://jekyllrb.com/), [Normalize.css](http://necolas.github.io/normalize.css/), and icons from [Font Awesome](http://fontawesome.io/). Video stream source code from [Toronto Mesh](https://github.com/tomeshnet/ipfs-live-streaming/) and [Video.js](https://videojs.com), graphic assets from [IPFS](https://github.com/ipfs/artwork) and loading animation from [jxnblk/loading](https://github.com/jxnblk/loading).
 
 Logo by [Marlo Yarlo](http://www.marloyarlo.com/). [2019 design concept](https://github.com/ournetworks/artwork) by Amelia Zhang.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/ournetworks/ournetworks.ca.svg?branch=master)](https://travis-ci.org/ournetworks/ournetworks.ca)
 
-This repository holds the source code and static assets of [ournetworks.ca](http://ournetworks.ca), built with [Jekyll](https://jekyllrb.com/), [Normalize.css](http://necolas.github.io/normalize.css/), and icons from [Font Awesome](http://fontawesome.io/). Video stream source code from [Toronto Mesh](https://github.com/tomeshnet/ipfs-live-streaming/) and [Video.js](https://videojs.com), graphic assets from [IPFS](https://github.com/ipfs/artwork) and loading animation from [jxnblk/loading](https://github.com/jxnblk/loading).
+This repository holds the source code and static assets of [ournetworks.ca](http://ournetworks.ca), built with [Jekyll](https://jekyllrb.com/), [Normalize.css](http://necolas.github.io/normalize.css/), and icons from [Font Awesome](http://fontawesome.io/). Previous releases have included video stream source code from [Toronto Mesh](https://github.com/tomeshnet/ipfs-live-streaming/) and [Video.js](https://videojs.com), graphic assets from [IPFS](https://github.com/ipfs/artwork) and loading animation from [jxnblk/loading](https://github.com/jxnblk/loading).
 
 Logo by [Marlo Yarlo](http://www.marloyarlo.com/). [2019 design concept](https://github.com/ournetworks/artwork) by Amelia Zhang.
 


### PR DESCRIPTION
@dcwalk brought up attributing design of Our Networks in the following repositories:

- https://github.com/tomeshnet/ipfs-live-streaming/
- https://github.com/hyphacoop/meshmedia/

I propose cross-attributing between tomeshnet/ipfs-live-streaming and here as they consider code and design from each other. Please let me know the preferred language for tomeshnet/ipfs-live-streaming, especially whether Our Networks will be attributed as an org or as personal contributions, and how/whether to recognize code vs. design contributions.

Whatever gets added to tomeshnet/ipfs-live-streaming I should carry over to hyphacoop/meshmedia.