### PR TITLE
Support sessionLink

### DIFF
--- a/_includes/session-details.html
+++ b/_includes/session-details.html
@@ -3,7 +3,13 @@
   <a class="program-block-anchor" {% unless session.skipProgramID %}id="{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}"{% endunless %}></a>
   <div class="program-block-content p-1">
     <header class="session-header mb-1">
-      <h3 class="session-title heading">{{ session.title }}</h3>
+      <h3 class="session-title heading">
+        {% if session.sessionLink %}
+          <a href="{{ session.sessionLink }}" target="_blank">{{ session.title }}</a>
+        {%else%}
+          {{ session.title }}
+        {% endif %}
+      </h3>
       <ul class="ls-none p-0 flex fs-medium">
       {% for item in session.sessionType %}
         <li class="highlight p-05 mr-05 mono">{{ item | capitalize | replace: '-', ' ' }}</li>
@@ -54,6 +60,11 @@
     {%- if session.descriptionLink -%}
       <div class="read-more mono fs-medium"><a href="{{ session.descriptionLink }}" rel="noopener">Read more</a></div>
     {%- endif -%}
+    {% if session.sessionLink %}
+      <div class="mt-1">
+      <a class="button bg-black color-white" href="{{ session.sessionLink }}" target="_blank">Visit {{ session.title }}</a>
+      </div>
+    {% endif %}
     {%- if session.link or session.twitter or session.github -%}
     <ul class="bio-sm-list">
      {%- if session.link and session.linkDisplay -%}<li class="bio-sm-list-item"><a href="{{ session.link }}" target="_blank" rel="noopener">{{ session.linkDisplay }} </a></li>{%- endif -%}
@@ -63,7 +74,7 @@
     </ul>
     {%- endif -%}
     <div class="session-jump none">
-      <a href="#{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}-schedule" class="mt-2 compact bg-black color-white button">Back to schedule</a>
+      <a href="#{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}-schedule" class="mt-2 compact color-black button">Back to schedule</a>
     </div>
     
   </div>

--- a/_includes/session-exhibited-works.html
+++ b/_includes/session-exhibited-works.html
@@ -8,7 +8,13 @@
     {%- for session in sortedSessions -%}
       {%- if session.sessionType contains "exhibit" and session.sessionID != 20005 -%}
       <li class="mt-05 w-50 pr-1">
-        <h5 class="m-0"><a id="{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}-schedule" href="#{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}">{{ session.title }}</a></h5>
+        <h5 class="m-0">
+          {% if session.sessionLink %}
+            <a href="{{ session.sessionLink }}" target="_blank" title="Visit work at {{ session.sessionLink }}">{{ session.title }}</a>
+          {% else %}
+            <a id="{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}-schedule" href="#{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}">{{ session.title }}</a>
+          {% endif %}
+        </h5>
         {% assign presenterCount = session.presenterID.size %}
         <h6 class="fw-normal session-presenterID mono fs-small mt-05 mb-1">
         {%- for presenterID in session.presenterID -%}
@@ -21,6 +27,9 @@
           {{ name }}{%- if presenterCount > 0 -%}, {%- endif -%}
         {%- endfor -%}
         </h6>
+        {% if session.sessionLink %}
+          <p><a class="fs-small fw-normal mono" id="{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}-schedule" href="#{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}">Read more</a></p>
+        {% endif %}
       </li>
       {%- endif -%}
     {%- endfor -%}

--- a/_includes/session.html
+++ b/_includes/session.html
@@ -4,9 +4,13 @@
     <a class="schedule-block-anchor" {% unless session.skipProgramID %}id="{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}-schedule"{% endunless %}></a>
     <header>
       <h5 class="mt-0 session-title">
-        {%- unless session.sessionType == "orga" or session.sessionType == "hangout" -%}<a href="#{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}" class="session-title-link">{%- endunless -%}
+        {% if session.sessionLink %}
+          <a href="{{ session.sessionLink }}" target="_blank" title="Visit work at {{ session.sessionLink }}">{{ session.title }}</a>
+        {% else %}
+          {%- unless session.sessionType == "orga" or session.sessionType == "hangout" -%}<a href="#{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}" class="session-title-link">{%- endunless -%}
           {{ session.title }}
-        {%- unless session.sessionType == "orga" or session.sessionType == "hangout"-%}</a>{%- endunless -%}
+          {%- unless session.sessionType == "orga" or session.sessionType == "hangout"-%}</a>{%- endunless -%}
+        {% endif %}
       </h5>
       {%- unless session.sessionType contains "orga" -%}
         <ul class="ls-none p-0 mt-05 mb-1 flex flex-wrap fs-small">
@@ -34,6 +38,12 @@
     </header>
     {%- if include.sessionCaption -%}
       <p class="mt-1 mono fs-medium">{{include.sessionCaption}}</p>
+    {% endif %}
+
+    {% if session.sessionLink %}
+      {%- unless session.sessionType == "orga" or session.sessionType == "hangout" -%}<a href="#{{ session.title | truncatewords: 6, '' | downcase | replace: ':', '' | replace: ' ', '-' }}" class="mono fs-medium session-title-link">{%- endunless -%}
+        Read more
+      {%- unless session.sessionType == "orga" or session.sessionType == "hangout"-%}</a>{%- endunless -%}
     {% endif %}
   </div>
   {%- endif -%}


### PR DESCRIPTION
Adding `sessionLink` causes:
- Schedule title links directly to `sessionLink` with `Read more` going to the program block
- The session title in the program block links to the `sessionLink` with an additional button below the description text