### PR TITLE
Added rocketchat iframe to livestream

### DIFF
--- a/_includes/live-stream-embed.html
+++ b/_includes/live-stream-embed.html
@@ -2,7 +2,7 @@
   <div class="absolute w-100 h-100 player"></div>
 </div>
 
-<iframe class="video-chat" src="https://rocketchat.ournetworks.ca/channel/general"></iframe>
+<iframe class="video-chat border-0" src="https://rocketchat.ournetworks.ca/channel/general"></iframe>
 
 <script src="/js/vendor/clappr.min.js?{{site.time | date: '%s%N'}}"></script>
 <script src="/js/vendor/level-selector.min.js?{{site.time | date: '%s%N'}}"></script>

--- a/_includes/live-stream-embed.html
+++ b/_includes/live-stream-embed.html
@@ -2,7 +2,7 @@
   <div class="absolute w-100 h-100 player"></div>
 </div>
 
-<iframe class="video-chat border-0" src="https://rocketchat.ournetworks.ca/channel/general"></iframe>
+<iframe class="video-chat border-0" src="https://rocketchat.ournetworks.ca/channel/general?layout=embedded"></iframe>
 
 <script src="/js/vendor/clappr.min.js?{{site.time | date: '%s%N'}}"></script>
 <script src="/js/vendor/level-selector.min.js?{{site.time | date: '%s%N'}}"></script>

--- a/_includes/live-stream-embed.html
+++ b/_includes/live-stream-embed.html
@@ -2,6 +2,8 @@
   <div class="absolute w-100 h-100 player"></div>
 </div>
 
+<iframe class="video-chat" src="https://rocketchat.ournetworks.ca/channel/general"></iframe>
+
 <script src="/js/vendor/clappr.min.js?{{site.time | date: '%s%N'}}"></script>
 <script src="/js/vendor/level-selector.min.js?{{site.time | date: '%s%N'}}"></script>
 <script src="/js/live-stream-embed.js?{{site.time | date: '%s%N'}}"></script>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -345,6 +345,10 @@
   border-top: 5px solid $accent-color;
 }
 
+.border-0 {
+  border: 0;
+}
+
 // BG element
 
 .bg-element {

--- a/_sass/_videos.scss
+++ b/_sass/_videos.scss
@@ -38,3 +38,8 @@
 .video-embed-16by9 {
   padding-bottom: 56.25%;
 }
+
+.video-chat {
+  width: 100%;
+  height: 333px;
+}

--- a/_sass/_videos.scss
+++ b/_sass/_videos.scss
@@ -41,5 +41,5 @@
 
 .video-chat {
   width: 100%;
-  height: 333px;
+  height: 400px;
 }


### PR DESCRIPTION
I added the chat underneath the video since there wasn't that much horizontal space.

Doesn't look like it works on localhost, but I had it working on the proper ournetworks page when manually injecting HTML in the inspector.